### PR TITLE
feat: support long message sign for PersonalSign

### DIFF
--- a/src/view/screen/notifications/sign/api.ts
+++ b/src/view/screen/notifications/sign/api.ts
@@ -26,6 +26,7 @@ export const usePersonalSignMutation = () => {
       throw new Error("Missing sign data");
     }
 
+    const valueHash = nacl.hash(Buffer.from(value, "utf8"));
     /**
      * According: https://github.com/ton-foundation/specs/blob/main/specs/wtf-0002.md
      */
@@ -37,7 +38,7 @@ export const usePersonalSignMutation = () => {
     const hex = Buffer.concat([
       Buffer.from([0xff, 0xff]),
       Buffer.from("ton-safe-sign-magic"),
-      Buffer.from(value, "utf8"),
+      valueHash,
     ]).toString("hex");
 
     const keyPair = await getWalletKeyPair(wallet);

--- a/src/view/screen/notifications/sign/api.ts
+++ b/src/view/screen/notifications/sign/api.ts
@@ -31,7 +31,7 @@ export const usePersonalSignMutation = () => {
      * According: https://github.com/ton-foundation/specs/blob/main/specs/wtf-0002.md
      */
 
-    if (value.length + "ton-safe-sign-magic".length >= 127) {
+    if (valueHash.length + "ton-safe-sign-magic".length >= 127) {
       throw new Error("Too large personal message");
     }
 


### PR DESCRIPTION
As [it](https://github.com/ton-foundation/specs/blob/main/specs/wtf-0002.md) describes, the message is hashed first, so that messages of any length can be supported

@KuznetsovNikita 